### PR TITLE
Wsc name fix

### DIFF
--- a/lm_eval/tasks/__init__.py
+++ b/lm_eval/tasks/__init__.py
@@ -27,7 +27,7 @@ TASK_REGISTRY = {
     "copa": superglue.Copa,
     "multirc": superglue.MultiRC,
     "wic": superglue.WordsInContext,
-    "wsc": superglue.WinogradSchemaChallenge,
+    "wsc": superglue.WSC,
     # Order by benchmark/genre?
     "arc_easy": arc.ARCEasy,
     "arc_challenge": arc.ARCChallenge,

--- a/lm_eval/tasks/superglue.py
+++ b/lm_eval/tasks/superglue.py
@@ -218,7 +218,7 @@ class WordsInContext(HFTask):
         return simple_accuracy_metric(preds=preds, golds=golds)
 
 
-class WinogradSchemaChallenge(HFTask):
+class WSC(HFTask):
     DATASET_PATH = "super_glue"
     DATASET_NAME = "wsc"
 


### PR DESCRIPTION
Changes name of SuperGLUE Winograd Schemas Challenge to WSC. Distinct from WSC273, WNLI, and Winogrande.

Separately, this task might need an update, since it looks like it calls some functions from a previous version of this repo.