### PR TITLE
add Wikitext2 + wikitext103 data

### DIFF
--- a/lm_eval/tasks/wikitext.py
+++ b/lm_eval/tasks/wikitext.py
@@ -1,0 +1,30 @@
+import numpy as np
+from scipy.stats import pearsonr, spearmanr
+from sklearn.metrics import f1_score, matthews_corrcoef
+from tqdm import auto as tqdm_lib
+from . common import NLP_TASK, simple_accuracy_metric, yesno
+
+class WikiText103(NLP_TASK):
+    NLP_PATH = "wikitext"
+    NLP_NAME = "wikitext-103-raw-v1"
+
+    def fewshot_description(self):
+        return ""
+
+    def doc_to_text(self, doc, include_target=True):
+        return doc['text']
+    def evaluate(self, docs, lm, provide_description, num_fewshot):
+        pass
+
+
+class WikiText2(NLP_TASK):
+    NLP_PATH = "wikitext"
+    NLP_NAME = "wikitext-2-raw-v1"
+
+    def fewshot_description(self):
+        return ""
+
+    def doc_to_text(self, doc, include_target=True):
+        return doc['text']
+    def evaluate(self, docs, lm, provide_description, num_fewshot):
+        pass


### PR DESCRIPTION
Add wikitext2 and wikitext3 data for dedup. It's unclear how it should be broken up into docs so I will revist it once I can find more examples of how other people break it up. For reference Huggingface and https://blog.einstein.ai/the-wikitext-long-term-dependency-language-modeling-dataset/ both say to split docs at newlines but that results in empty docs and docs with only a header. 